### PR TITLE
- Added support generating Poco.framework with support for armv7s, ar…

### DIFF
--- a/Platform/iOS/build_ios.sh
+++ b/Platform/iOS/build_ios.sh
@@ -43,6 +43,7 @@ iPhoneARCH7=armv7
 iPhoneARCH7s=armv7s
 iPhoneARCH64=arm64
 SIMULATOR_ARCH=i686
+SIMULATOR_ARCH64=x86_64
 
 # Locate ar
 ARM_BINARY_AR=`xcrun --sdk iphoneos -find ar`
@@ -74,9 +75,10 @@ CURRENT_DIR=${PWD}
 FRAMEWORKDIR=$2/iOS/framework
 
 PATH_TO_LIBS_i386=$3
-PATH_TO_LIBS_ARM7=$4
-PATH_TO_LIBS_ARM7s=$5
-PATH_TO_LIBS_ARM64=$6
+PATH_TO_LIBS_x86_64=$4
+PATH_TO_LIBS_ARM7=$5
+PATH_TO_LIBS_ARM7s=$6
+PATH_TO_LIBS_ARM64=$7
 
 FRAMEWORK_BUNDLE=$FRAMEWORKDIR/$FRAMEWORK_NAME.framework
 
@@ -105,7 +107,9 @@ do
 echo "Decomposing $file for iPhoneSimulator..."
 #mkdir -p $PATH_TO_LIBS_i386/obj
 mkdir -p $PATH_TO_LIBS_i386/${file}
+mkdir -p $PATH_TO_LIBS_x86_64/${file}
 (cd $PATH_TO_LIBS_i386/$file; $DEV_BINARY_AR -x ../libPoco$file.a );
+(cd $PATH_TO_LIBS_x86_64/$file; $DEV_BINARY_AR -x ../libPoco$file.a );
 done
 
 for file in {Foundation$DEBUG,Util$DEBUG,XML$DEBUG,Net$DEBUG,NetSSL$DEBUG,Crypto$DEBUG,Data$DEBUG,DataSQLite$DEBUG}
@@ -124,6 +128,7 @@ doneSection
 witeMessage "Linking each architecture into a libPoco${DEBUG}.a"
 echo "Linking objects for iPhoneSimulator..."
 (cd $PATH_TO_LIBS_i386; $DEV_BINARY_AR crus libPoco${DEBUG}.a Foundation$DEBUG/*.o Util$DEBUG/*.o XML$DEBUG/*.o Net$DEBUG/*.o NetSSL$DEBUG/*.o Crypto$DEBUG/*.o Data$DEBUG/*.o DataSQLite$DEBUG/*.o );
+(cd $PATH_TO_LIBS_x86_64; $DEV_BINARY_AR crus libPoco${DEBUG}.a Foundation$DEBUG/*.o Util$DEBUG/*.o XML$DEBUG/*.o Net$DEBUG/*.o NetSSL$DEBUG/*.o Crypto$DEBUG/*.o Data$DEBUG/*.o DataSQLite$DEBUG/*.o );
 echo "Linking objects for iPhoneOS..."
 (cd $PATH_TO_LIBS_ARM7; $DEV_BINARY_AR crus libPoco${DEBUG}.a Foundation$DEBUG/*.o Util$DEBUG/*.o XML$DEBUG/*.o Net$DEBUG/*.o NetSSL$DEBUG/*.o Crypto$DEBUG/*.o Data$DEBUG/*.o DataSQLite$DEBUG/*.o );
 (cd $PATH_TO_LIBS_ARM7s; $DEV_BINARY_AR crus libPoco${DEBUG}.a Foundation$DEBUG/*.o Util$DEBUG/*.o XML$DEBUG/*.o Net$DEBUG/*.o NetSSL$DEBUG/*.o Crypto$DEBUG/*.o Data$DEBUG/*.o DataSQLite$DEBUG/*.o );
@@ -134,6 +139,7 @@ for file in {Foundation$DEBUG,Util$DEBUG,XML$DEBUG,Net$DEBUG,NetSSL$DEBUG,Crypto
 do
 echo "Cleaning $file..."
 rm -rf $PATH_TO_LIBS_i386/${file}
+rm -rf $PATH_TO_LIBS_x86_64/${file}
 rm -rf $PATH_TO_LIBS_ARM7/${file}
 rm -rf $PATH_TO_LIBS_ARM7s/${file}
 rm -rf $PATH_TO_LIBS_ARM64/${file}
@@ -146,6 +152,7 @@ FRAMEWORK_INSTALL_NAME=$FRAMEWORK_BUNDLE/Versions/$FRAMEWORK_VERSION/$FRAMEWORK_
 xcrun -sdk iphoneos lipo \
 -create \
 -arch i386 "$PATH_TO_LIBS_i386/libPoco${DEBUG}.a" \
+-arch x86_64 "$PATH_TO_LIBS_x86_64/libPoco${DEBUG}.a" \
 -arch armv7 "$PATH_TO_LIBS_ARM7/libPoco${DEBUG}.a" \
 -arch armv7s "$PATH_TO_LIBS_ARM7s/libPoco${DEBUG}.a" \
 -arch arm64 "$PATH_TO_LIBS_ARM64/libPoco${DEBUG}.a" \
@@ -196,7 +203,8 @@ cd $POCO
 --no-samples \
 --omit=$POCO_OMIT
 
-make -j32
+make -j32 POCO_TARGET_OSARCH=i686
+make -j32 POCO_TARGET_OSARCH=x86_64
 
 ./configure \
 --config=iPhone-clang-libc++ \
@@ -209,4 +217,4 @@ make -j32 POCO_TARGET_OSARCH=armv7
 make -j32 POCO_TARGET_OSARCH=armv7s
 make -j32 POCO_TARGET_OSARCH=arm64
 
-buildFramework 'RELEASE' ${PWD}/lib `pwd`/lib/iPhoneSimulator/$SIMULATOR_ARCH `pwd`/lib/iPhoneOS/$iPhoneARCH7  `pwd`/lib/iPhoneOS/$iPhoneARCH7s  `pwd`/lib/iPhoneOS/$iPhoneARCH64
+buildFramework 'RELEASE' ${PWD}/lib `pwd`/lib/iPhoneSimulator/$SIMULATOR_ARCH `pwd`/lib/iPhoneSimulator/$SIMULATOR_ARCH64 `pwd`/lib/iPhoneOS/$iPhoneARCH7  `pwd`/lib/iPhoneOS/$iPhoneARCH7s  `pwd`/lib/iPhoneOS/$iPhoneARCH64


### PR DESCRIPTION
- Added support for generating Poco.framework with armv7s, arm64 architectures. Now Poco.framework has support for i686, x86_64, armv7, armv7s, arm64 architectures 
- Added support for safer discovery of ar binary 
- Provided sane default for omitted poco libraries (POCO_OMIT env variable)